### PR TITLE
feat(run-once): add run-once option to generator

### DIFF
--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 
 	"ctx.sh/genie/pkg/cmd"
 	"ctx.sh/strata"
+	"github.com/go-logr/logr"
 	"github.com/go-logr/zapr"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -44,7 +45,8 @@ func main() {
 	// Metrics
 	logger := zapr.NewLogger(zl)
 	metrics := strata.New(strata.MetricsOpts{
-		Logger:       logger,
+		// Enable later
+		Logger:       logr.Discard(),
 		Prefix:       []string{"genie"},
 		PanicOnError: true,
 	})

--- a/pkg/cmd/generate.go
+++ b/pkg/cmd/generate.go
@@ -18,11 +18,12 @@ event generators will be run on startup. Individual events can be specified by u
 name. Generate specific arguments can be added as after the event name.`
 
 type Generate struct {
-	logger  logr.Logger
-	metrics *strata.Metrics
-	once    bool
-	ctx     context.Context
-	sink    string
+	logger     logr.Logger
+	metrics    *strata.Metrics
+	once       bool
+	enableLogs bool
+	ctx        context.Context
+	sink       string
 }
 
 func NewGenerate(opts *GlobalOpts) *Generate {
@@ -34,6 +35,17 @@ func NewGenerate(opts *GlobalOpts) *Generate {
 }
 
 func (g *Generate) RunE(cmd *cobra.Command, args []string) error {
+	ctx, cancel := context.WithCancel(g.ctx)
+	defer cancel()
+
+	if g.once && cmd.Flags().Lookup("enable-logs") == nil {
+		g.enableLogs = false
+	}
+
+	if !g.enableLogs {
+		g.logger = logr.Discard()
+	}
+
 	// TODO: I'm probably going to move the subsequential parsing into
 	// the objects into the load stage.
 	path := cmd.Flag("config").Value.String()
@@ -53,6 +65,7 @@ func (g *Generate) RunE(cmd *cobra.Command, args []string) error {
 		Logger:  g.logger,
 		Metrics: g.metrics,
 		Sinks:   cfg.Sinks,
+		RunOnce: g.once,
 	})
 
 	var evts []string
@@ -65,12 +78,21 @@ func (g *Generate) RunE(cmd *cobra.Command, args []string) error {
 	manager.Enable(evts...)
 
 	g.logger.Info("starting sinks")
-	cfg.Sinks.StartAll(g.ctx)
+	cfg.Sinks.StartAll()
 
-	g.logger.Info("starting manager")
-	if err := manager.Start(g.ctx); err != nil {
-		os.Exit(1)
+	// Wait for context if we are not running once.
+	if !g.once {
+		g.logger.Info("starting events manager")
+		manager.StartAll()
+		<-ctx.Done()
+
+		g.logger.Info("shutting down event generators")
+		manager.StopAll()
+	} else {
+		manager.RunOnce()
 	}
+
+	cfg.Sinks.StopAll()
 
 	return nil
 }
@@ -83,7 +105,10 @@ func (g *Generate) Command() *cobra.Command {
 		RunE:  g.RunE,
 	}
 	cmd.PersistentFlags().StringVarP(&g.sink, "sink", "s", "", "Override the configured sinks with the sinks provided.")
-	cmd.PersistentFlags().BoolVar(&g.once, "run-once", false, "Run the generator one time and exit.")
+	cmd.PersistentFlags().BoolVar(&g.once, "run-once", false, "Run the generator one time and exit.  Logging is disabled by default, when run-once is enabled.  Use --enable-logs to enable.")
+	cmd.PersistentFlags().BoolVar(&g.enableLogs, "enable-logs", true, "Enable log output.")
+	cmd.PersistentFlags().BoolVar(&g.enableLogs, "disable-logs", false, "Enable log output.")
+	cmd.MarkFlagsMutuallyExclusive("enable-logs", "disable-logs")
 
 	return cmd
 }

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -62,7 +62,6 @@ func (r *Root) Command() *cobra.Command {
 		Logger:      r.logger,
 		Metrics:     r.metrics,
 		BaseContext: r.ctx,
-		CancelFunc:  r.cancel,
 	}
 
 	rootCmd.AddCommand(NewGenerate(opts).Command())

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -77,7 +77,10 @@ func Load(opts *LoadOptions) (*Config, error) {
 		return nil, err
 	}
 
-	snks, err := sinks.Parse(config.Sinks, res, &sinks.Options{})
+	snks, err := sinks.Parse(config.Sinks, res, &sinks.Options{
+		Logger:  opts.Logger,
+		Metrics: opts.Metrics,
+	})
 	if err != nil {
 		opts.Logger.Error(err, "unable to parse sinks")
 		return nil, err


### PR DESCRIPTION
Adds an option to only run a single time.  By default logging is enabled as it is assumed that the option will be used locally while developing resources/events.  In working through this, I discovered some sync issues on the channel shutdown, so I changed up the pattern a bit so we are using the closing the send channel instead of using a stop channel.