### PR TITLE
chore(sinks): remove sinks from the event config

### DIFF
--- a/genie.d/sinks.yaml
+++ b/genie.d/sinks.yaml
@@ -1,11 +1,4 @@
 sinks:
-  # kafka:
-  #   kind:
-  #     topic: events
-  #     brokers:
-  #       - analytics-0.analytics.strataviz.svc.cluster.local:9092
-  #     # Add key and value serializers?
-  #     # Optional create topic if not exists
   http:
     localhost:
       url: http://localhost:8080

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,14 +1,25 @@
 package config
 
-// func TestLoadAll(t *testing.T) {
-// 	path, err := os.Getwd()
-// 	require.NoError(t, err)
+import (
+	"fmt"
+	"os"
+	"testing"
 
-// 	dir := fmt.Sprintf("%s/../../genie.d", path)
-// 	_, err = Load(&LoadOptions{
-// 		Paths:   []string{dir},
-// 		Logger:  logr.Discard(),
-// 		Metrics: strata.New(strata.MetricsOpts{}),
-// 	})
-// 	assert.NoError(t, err)
-// }
+	"ctx.sh/strata"
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadAll(t *testing.T) {
+	path, err := os.Getwd()
+	require.NoError(t, err)
+
+	dir := fmt.Sprintf("%s/../../genie.d", path)
+	_, err = Load(&LoadOptions{
+		Paths:   []string{dir},
+		Logger:  logr.Discard(),
+		Metrics: strata.New(strata.MetricsOpts{}),
+	})
+	assert.NoError(t, err)
+}

--- a/pkg/events/config.go
+++ b/pkg/events/config.go
@@ -9,7 +9,6 @@ type EventConfig struct {
 	Vars        []variables.Config `yaml:"vars"`
 	Template    string             `yaml:"template"`
 	Raw         string             `yaml:"raw"`
-	Sinks       []string           `yaml:"sink"`
 }
 
 func (e *EventConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
@@ -20,7 +19,6 @@ func (e *EventConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		Vars        []variables.Config `yaml:"vars"`
 		Template    string             `yaml:"template"`
 		Raw         string             `yaml:"raw"`
-		Sinks       []string           `yaml:"sink"`
 	}
 
 	var defaults = EventConfigDefaults{
@@ -31,10 +29,6 @@ func (e *EventConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 	if err := unmarshal(&out); err != nil {
 		return err
-	}
-
-	if out.Sinks == nil {
-		out.Sinks = []string{"stdout"}
 	}
 
 	evt := EventConfig(out)

--- a/pkg/events/manager.go
+++ b/pkg/events/manager.go
@@ -3,112 +3,39 @@ package events
 import (
 	"context"
 	"sync"
-
-	"ctx.sh/strata"
-	"github.com/go-logr/logr"
-	"stvz.io/genie/pkg/sinks"
 )
-
-type ManagerOptions struct {
-	Logger  logr.Logger
-	Metrics *strata.Metrics
-	Sinks   *sinks.Sinks
-	RunOnce bool
-}
 
 type Manager struct {
 	// add logging
-	events Events
-	once   bool
-
-	logger  logr.Logger
-	metrics *strata.Metrics
-	sinks   *sinks.Sinks
-
-	wg       sync.WaitGroup
+	events   []*Event
 	stopOnce sync.Once
 
-	sync.RWMutex
+	sync.Mutex
 }
 
-func NewManager(events Events, opts *ManagerOptions) *Manager {
+func NewManager() *Manager {
 	return &Manager{
-		events:  events,
-		logger:  opts.Logger,
-		metrics: opts.Metrics,
-		sinks:   opts.Sinks,
-		once:    opts.RunOnce,
+		events: make([]*Event, 0),
 	}
 }
 
-// TODO: I don't like this.  Remove the sink discovery from the manager
-// and pass in the sinks that are specified on the command line, taking
-// out all of the logic for sink configuration in the config file to simplify
-// use.
-func (m *Manager) Enable(sink string, names ...string) {
-	for _, name := range names {
-		if _, ok := m.events[name]; !ok {
-			m.logger.Info("event not found", "name", name)
-			continue
-		}
-
-		var sendChan chan<- []byte
-		sendChan, err := m.sinks.Get(sink)
-		if err != nil {
-			sendChan = m.sinks.Stdout.SendChannel()
-		}
-
-		m.events[name].
-			WithSendChannel(sendChan).
-			Enable()
-	}
-}
-
-func (m *Manager) RunOnce() {
-	for _, g := range m.events {
-		if !g.enabled {
-			continue
-		}
-
-		g.run()
-	}
-}
-
-func (m *Manager) StartAll() {
+// TODO: There's a possibility that I'll allow the configuration of
+// multiple sinks in the future.  It's just a single for now.
+func (m *Manager) Start(ctx context.Context, event *Event, sendChan chan<- []byte) {
 	m.Lock()
 	defer m.Unlock()
 
-	ctx := context.Background()
-	metrics := m.metrics.WithLabels("event")
-	for n, g := range m.events {
-		// TODO: not a fan of this, we should initially filter out the
-		// disabled events.
-		if !g.enabled {
-			metrics.CounterInc("event_disabled", n)
-			continue
-		}
-
-		m.wg.Add(1)
-		go func(g *Event) {
-			defer m.wg.Done()
-			g.Start(ctx)
-		}(g)
-	}
+	m.events = append(m.events, event)
+	event.Start(ctx, sendChan)
 }
 
-func (m *Manager) StopAll() {
+func (m *Manager) Stop() {
 	m.Lock()
 	defer m.Unlock()
 
 	m.stopOnce.Do(func() {
 		for _, g := range m.events {
-			// TODO: have a started map that we can check here
-			if g.enabled {
-				g.logger.Info("stopping event generator", "name", g.name)
-				g.Stop()
-			}
+			g.Stop()
 		}
-
-		m.wg.Wait()
 	})
 }


### PR DESCRIPTION
This removes the sink reference from the event config in favor of specifying the sink on the command line, where I expect it will be used more often since this is a test/dev tool. As part of the change to simplify things, I also pulled the sink dependency from the manager and minimized the resources that it needed to know about.  The generator command will now get the sink and pass the channel to the manager on startup.  Manager is now a simple wrapper around event startup and only needs to track the events that it has started.

There's a possiblity that I'll follow up this PR with a new one that allows the user to specify multiple sinks to start which would also required sending multiple channels to the events, but for now this works sufficiently well.  In the case that I do that, I'll move the sink initialization and start into the sink package and out of the generator.