### PR TITLE
fix(http): pass resources into the sink

### DIFF
--- a/examples/sinks.yaml
+++ b/examples/sinks.yaml
@@ -1,7 +1,7 @@
 sinks:
   http:
     localhost:
-      url: http://localhost:8080
+      url: http://localhost:8081
       method: post
       headers:
         - name: Content-Type

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -67,8 +67,9 @@ func Load(opts *LoadOptions) (*Config, error) {
 
 	res := resources.New(config.Resources)
 	snks := sinks.New(config.Sinks, &sinks.Options{
-		Logger:  opts.Logger,
-		Metrics: opts.Metrics,
+		Logger:    opts.Logger,
+		Metrics:   opts.Metrics,
+		Resources: res,
 	})
 
 	evts, err := events.Parse(config.Events, &events.Options{

--- a/pkg/sinks/http/http.go
+++ b/pkg/sinks/http/http.go
@@ -15,8 +15,9 @@ import (
 
 // Options are the options for an HTTP sink.
 type Options struct {
-	Logger  logr.Logger
-	Metrics *strata.Metrics
+	Logger    logr.Logger
+	Metrics   *strata.Metrics
+	Resources *resources.Resources
 }
 
 // HTTP is an HTTP sink.
@@ -41,12 +42,13 @@ type HTTP struct {
 // New returns a new HTTP sink.
 func New(cfg Config, opts *Options) *HTTP {
 	return &HTTP{
-		url:      cfg.URL,
-		method:   cfg.Method,
-		headers:  newHeaders(cfg.Headers),
-		sendChan: make(chan []byte),
-		logger:   opts.Logger,
-		metrics:  opts.Metrics,
+		url:       cfg.URL,
+		method:    cfg.Method,
+		headers:   newHeaders(cfg.Headers),
+		sendChan:  make(chan []byte),
+		logger:    opts.Logger,
+		metrics:   opts.Metrics,
+		resources: opts.Resources,
 	}
 }
 

--- a/pkg/sinks/sinks.go
+++ b/pkg/sinks/sinks.go
@@ -6,6 +6,7 @@ import (
 
 	"ctx.sh/strata"
 	"github.com/go-logr/logr"
+	"stvz.io/genie/pkg/resources"
 	"stvz.io/genie/pkg/sinks/http"
 	"stvz.io/genie/pkg/sinks/kafka"
 	"stvz.io/genie/pkg/sinks/stdout"
@@ -21,8 +22,9 @@ type Sink interface {
 
 // Options are the options for a collection of configured sinks.
 type Options struct {
-	Logger  logr.Logger
-	Metrics *strata.Metrics
+	Logger    logr.Logger
+	Metrics   *strata.Metrics
+	Resources *resources.Resources
 }
 
 // Sinks is a collection of configured sinks.
@@ -60,8 +62,9 @@ func parseHTTPSinks(cfg Config, opts *Options) map[string]Sink {
 
 	for k, v := range cfg.HTTP {
 		sink := http.New(v, &http.Options{
-			Logger:  opts.Logger.WithValues("type", "http", "name", k),
-			Metrics: opts.Metrics.WithPrefix("http"),
+			Logger:    opts.Logger.WithValues("type", "http", "name", k),
+			Metrics:   opts.Metrics.WithPrefix("http"),
+			Resources: opts.Resources,
 		})
 		sinks[k] = sink
 	}

--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -69,6 +69,7 @@ func (t *Template) CompileFrom(file string) error {
 // in with events).  It's going to be required if we allow our templates to be used
 // in other configurations (i.e. sinks).
 func (t *Template) Execute(res *resources.Resources, vars *variables.Variables) string {
+	// TODO: concurrent map writes on the variables here...
 	return t.eval(t.root, res, variables.NewScopedVariables(vars))
 }
 

--- a/pkg/variables/variable.go
+++ b/pkg/variables/variable.go
@@ -1,10 +1,13 @@
 package variables
 
+import "sync"
+
 // Variables is a collection of variable names and values.
 type Variables struct {
 	// how to handle this?  I'll just use a map for now, but I think I want something more
 	// with type references and such.
 	vars map[string]string
+	sync.Mutex
 }
 
 // Parse parses a collection of variable configs into a Variables object.
@@ -20,12 +23,18 @@ func Parse(block []Config) (*Variables, error) {
 
 // Get returns the value of a variable in the collection.
 func (v *Variables) Get(name string) (string, bool) {
+	v.Lock()
+	defer v.Unlock()
+
 	val, ok := v.vars[name]
 	return val, ok
 }
 
 // Set sets the value of a variable in the collection.
 func (v *Variables) Set(name, value string) error {
+	v.Lock()
+	defer v.Unlock()
+
 	v.vars[name] = value
 	return nil
 }


### PR DESCRIPTION
Hadn't had a chance to really use the http sink and when I did, realized that we weren't passing the resources into the sink for the templateable headers. 