### PR TITLE
fix(sinks): ensure uppercase on http method

### DIFF
--- a/examples/sinks.yaml
+++ b/examples/sinks.yaml
@@ -1,7 +1,7 @@
 sinks:
   http:
     localhost:
-      url: http://localhost:8081
+      url: http://localhost:8081/ingest
       method: post
       headers:
         - name: Content-Type

--- a/pkg/sinks/http/http.go
+++ b/pkg/sinks/http/http.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"io"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -43,7 +44,7 @@ type HTTP struct {
 func New(cfg Config, opts *Options) *HTTP {
 	return &HTTP{
 		url:       cfg.URL,
-		method:    cfg.Method,
+		method:    strings.ToUpper(cfg.Method),
 		headers:   newHeaders(cfg.Headers),
 		sendChan:  make(chan []byte),
 		logger:    opts.Logger,


### PR DESCRIPTION
Ran into an issue where certain proxies are case sensitive in regards to the method that is sent on the headers.  This ensures that they will always be uppercase.