### PR TITLE
fix(cmd): fix metrics race

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,82 +1,10 @@
 package main
 
 import (
-	"context"
-	"net/http"
-	"os"
-	"os/signal"
-	"sync"
-	"syscall"
-
 	"ctx.sh/genie/pkg/cmd"
-	"ctx.sh/strata"
-	"github.com/go-logr/logr"
-	"github.com/go-logr/zapr"
-	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
-)
-
-const (
-	DefaultMetricsPort = 9090
 )
 
 func main() {
-	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGSTOP)
-	defer cancel()
-
-	// Logging
-	encoderCfg := zap.NewProductionEncoderConfig()
-	encoderCfg.EncodeTime = zapcore.RFC3339NanoTimeEncoder
-	zapCfg := zap.Config{
-		// TODO: make me configurable
-		Level:       zap.NewAtomicLevelAt(zap.InfoLevel),
-		Development: false,
-		// TODO: enable this for debug mode
-		DisableStacktrace: true,
-		Sampling:          nil,
-		Encoding:          "console",
-		EncoderConfig:     encoderCfg,
-		OutputPaths: []string{
-			"stderr",
-		},
-		ErrorOutputPaths: []string{
-			"stderr",
-		},
-	}
-	zl := zap.Must(zapCfg.Build())
-	defer zl.Sync() //nolint:errcheck
-
-	// Metrics
-	logger := zapr.NewLogger(zl)
-	metrics := strata.New(strata.MetricsOpts{
-		// Enable later
-		Logger:       logr.Discard(),
-		Prefix:       []string{"genie"},
-		PanicOnError: true,
-	})
-
-	var obs sync.WaitGroup
-	obs.Add(1)
-	go func() {
-		defer obs.Done()
-		err := metrics.Start(strata.ServerOpts{
-			Port: DefaultMetricsPort,
-		})
-		if err != nil && err != http.ErrServerClosed {
-			logger.Error(err, "metrics server start failed")
-			os.Exit(1)
-		}
-	}()
-
-	root := cmd.NewRoot(&cmd.GlobalOpts{
-		Logger:      logger,
-		Metrics:     metrics,
-		BaseContext: ctx,
-		CancelFunc:  cancel,
-	})
+	root := cmd.NewRoot()
 	root.Execute()
-
-	// Shut down observability tools.
-	metrics.Stop()
-	obs.Wait()
 }

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -1,40 +1,19 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
 	"os"
 
 	"ctx.sh/genie/pkg/build"
-	"ctx.sh/strata"
-	"github.com/go-logr/logr"
 	"github.com/spf13/cobra"
 )
 
-// GlobalOpts are the global options for all commands.
-type GlobalOpts struct {
-	Logger      logr.Logger
-	Metrics     *strata.Metrics
-	BaseContext context.Context
-	CancelFunc  context.CancelFunc
-}
-
 // Root is the root command for the genie CLI.
-type Root struct {
-	logger  logr.Logger
-	metrics *strata.Metrics
-	ctx     context.Context
-	cancel  context.CancelFunc
-}
+type Root struct{}
 
 // NewRoot returns a new root command.
-func NewRoot(opts *GlobalOpts) *Root {
-	return &Root{
-		logger:  opts.Logger,
-		metrics: opts.Metrics,
-		ctx:     opts.BaseContext,
-		cancel:  opts.CancelFunc,
-	}
+func NewRoot() *Root {
+	return &Root{}
 }
 
 // Execute runs the root command.
@@ -60,14 +39,7 @@ values for the testing and validation of event pipelines.`,
 		},
 	}
 
-	// TODO: This needs to change.  Just keep the options around to repass
-	opts := &GlobalOpts{
-		Logger:      r.logger,
-		Metrics:     r.metrics,
-		BaseContext: r.ctx,
-	}
-
-	rootCmd.AddCommand(NewGenerate(opts).Command())
+	rootCmd.AddCommand(NewGenerate().Command())
 	rootCmd.PersistentFlags().StringP("config", "c", "./genie.d", "config file (default is $HOME/.genie.yaml)")
 
 	return rootCmd


### PR DESCRIPTION
Ran into a race condition where the metric server would not start up prior to stop being called.  It was always around the quick exits of commands like help and version and though they didn't show up running directly, they did appear when running those commands out of a container.

I pulled the logging and metrics into the generator since they would only need to be used in that context.  There will be some additional changes in strata to address it as well, but for right now we don't hit that race anymore.